### PR TITLE
Update minimum voltage value

### DIFF
--- a/custom_components/trmnl/const.py
+++ b/custom_components/trmnl/const.py
@@ -15,5 +15,5 @@ MIN_SCAN_INTERVAL = 60 # Minimum scan interval in seconds (1 minute)
 
 
 # Battery voltage limits
-MIN_VOLTAGE = 2.75  # Battery disconnects at this voltage
+MIN_VOLTAGE = 3.0  # Battery disconnects at this voltage
 MAX_VOLTAGE = 4.2   # Typical fully charged LiPo voltage


### PR DESCRIPTION
Hi,

Don’t know if that can help, but according to the TRMNL’s dashboard, the battery percentage is calculated from 4.2 V to 3.0 V.

For example, my TRMNL currently sits at 70 % for 3.85 V (shown when hovering the percentage). Calculation checks out: (3.85-3.0)*100/(4.2-3.0).

Cheers!