### PR TITLE
Fix: Ensure battery voltage is float before calculations

### DIFF
--- a/custom_components/trmnl/sensor.py
+++ b/custom_components/trmnl/sensor.py
@@ -97,7 +97,7 @@ class TrmnlBatterySensor(TrmnlBaseSensor):
         """Return the state of the sensor."""
         device_data = self.get_device_data()
         if device_data:
-            return device_data["battery_voltage"]
+            return float(device_data["battery_voltage"])
         return None
 
     @property
@@ -139,7 +139,7 @@ class TrmnlBatteryPercentageSensor(TrmnlBaseSensor):
         """Return the state of the sensor."""
         device_data = self.get_device_data()
         if device_data:
-            return calculate_battery_percentage(device_data["battery_voltage"])
+            return calculate_battery_percentage(float(device_data["battery_voltage"]))
         return None
 
     @property


### PR DESCRIPTION
The official BYOS Laravel implementation of the TRMNL API returns the battery voltage as a string representation of a floating point number instead of a direct floating point number in the API.

This leads to issues whenever the value is used for calculations and the types mismatch (e.g. for calculating battery percentage), and it also seems to cause all sensor values to no longer update - the plugin has to be reloaded or the HA server restarted in order for any TRMNL device values to update.

Before fix: ("Nicht verfügbar" is German for "not available")

![image](https://github.com/user-attachments/assets/eda262f7-fd1f-464f-847b-15c26925ce17)

After fix:

![image](https://github.com/user-attachments/assets/37647540-390a-4722-b6c5-c5657ad76ee9)


**To Reproduce**
Steps to reproduce the behavior:
1. Set up https://github.com/usetrmnl/byos_laravel
2. Hook up a TRMNL device to it
3. Configure the TRMNL device using this server in Home Assistant
4. Observe the values.

**Additional context**
Example API response from BYOS Laravel (I masked out address, device name, IDs and API key):

```
$ curl --header 'Content-type: application/json' --header 'Authorization: Bearer 2|<APIKEY>...' 'https://trmnl.<SERVERADDRESS>/api/devices?device_id=8'
{"data":[{"id":1,"name":"Example TRMNL","friendly_id":"ABCDEF","mac_address":"AA:BB:CC:DD:EE:FF","battery_voltage":"3.99","rssi":-62}]}
```