### PR TITLE
Fixed: 'Battery Percentage' output

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,23 @@
 
 This integration allows you to monitor your TRMNL e-ink display devices from Home Assistant, showing battery voltage, battery percentage, and WiFi signal strength.
 
+## Forked
+
+This repository is a fork. The original developer / integration is here:
+
+https://github.com/Beat2er/homeassistant-trmnl-battery
+
+All I've done is change the way the 'Battery Percentage' is worked out.
+
+I noticed the battery percentage reported by this integration is a little out. Around 9-10% in my case.
+
+Looking at the code as compared with a CURL response, I noticed the CURL response provides the 'percentage_charged', whereas this integration doesn't use that, rather uses the min and max voltages to work out the percentage. I don't know if perhaps this additional property is new and that's why it's not used?
+
+However this version reports the same battery percentage as what TRMNL is reporting now.
+
 ## Quick Add to HACS
 
-[![Open your Home Assistant instance and add this repository.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=Beat2er&repository=homeassistant-trmnl-battery&category=integration)
+[![Open your Home Assistant instance and add this repository.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jamesbrindle&repository=homeassistant-trmnl-battery&category=integration)
 
 ## Installation
 
@@ -17,7 +31,7 @@ This integration allows you to monitor your TRMNL e-ink display devices from Hom
 1. Ensure that [HACS](https://hacs.xyz/) is installed
 2. Go to HACS -> Integrations
 3. Click on the three dots in the top right corner and select "Custom repositories"
-4. Add `https://github.com/Beat2er/homeassistant-trmnl-battery` as a custom repository (Category: Integration)
+4. Add `https://github.com/jamesbrindle/homeassistant-trmnl-battery` as a custom repository (Category: Integration)
 5. Click "Install" on the TRMNL integration
 6. Restart Home Assistant
 

--- a/custom_components/trmnl/sensor.py
+++ b/custom_components/trmnl/sensor.py
@@ -15,15 +15,15 @@ from .const import DOMAIN, MIN_VOLTAGE, MAX_VOLTAGE, CONF_DEVICE_ACCESS_TOKEN # 
 
 _LOGGER = logging.getLogger(__name__)
 
-def calculate_battery_percentage(voltage):
-    """Calculate battery percentage based on voltage."""
-    if voltage <= MIN_VOLTAGE:
-        return 0
-    if voltage >= MAX_VOLTAGE:
-        return 100
-
-    percentage = ((voltage - MIN_VOLTAGE) / (MAX_VOLTAGE - MIN_VOLTAGE)) * 100
-    return round(percentage)
+# def calculate_battery_percentage(voltage):
+#    """Calculate battery percentage based on voltage."""
+#    if voltage <= MIN_VOLTAGE:
+#        return 0
+#    if voltage >= MAX_VOLTAGE:
+#        return 100
+#
+#    percentage = ((voltage - MIN_VOLTAGE) / (MAX_VOLTAGE - MIN_VOLTAGE)) * 100
+#    return round(percentage)
 
 async def async_setup_entry(
         hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -120,7 +120,7 @@ class TrmnlBatterySensor(TrmnlBaseSensor):
         """Return the icon of the sensor."""
         return "mdi:battery"
 
-
+# Altered class to use 'percentage_charged' from the API JSON response instead of calculating from min and max voltages
 class TrmnlBatteryPercentageSensor(TrmnlBaseSensor):
     """Representation of a TRMNL battery percentage sensor."""
 
@@ -138,8 +138,8 @@ class TrmnlBatteryPercentageSensor(TrmnlBaseSensor):
     def state(self):
         """Return the state of the sensor."""
         device_data = self.get_device_data()
-        if device_data:
-            return calculate_battery_percentage(float(device_data["battery_voltage"]))
+        if device_data and "percent_charged" in device_data:
+            return round(float(device_data["percent_charged"]))
         return None
 
     @property


### PR DESCRIPTION
I noticed the battery percentage reported by this integration is a little out. Around 9-10% in my case.

Looking at the code as compared with a CURL response, I noticed the CURL response provides the 'percentage_charged', whereas this integration doesn't use that, rather uses the min and max voltages to work out the percentage. I don't know if perhaps this additional property is new and that's why it's not used?