### PR TITLE
fix: show "already configured" instead of "unknown error" when re-adding the same trmnl account

### DIFF
--- a/custom_components/trmnl/config_flow.py
+++ b/custom_components/trmnl/config_flow.py
@@ -86,9 +86,6 @@ class TrmnlFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 try:
                     info = await self._validate_input(self.hass, processed_input)
-                    await self.async_set_unique_id(processed_input[CONF_API_KEY])
-                    self._abort_if_unique_id_configured()
-                    return self.async_create_entry(title=info["title"], data=processed_input)
                 except InvalidAuth:
                     errors["base"] = "invalid_auth"
                 except ConnectionError:
@@ -96,6 +93,14 @@ class TrmnlFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 except Exception:
                     _LOGGER.exception("Unexpected exception")
                     errors["base"] = "unknown"
+                else:
+                    # set_unique_id + abort_if_unique_id_configured must run OUTSIDE the
+                    # broad try/except above: AbortFlow inherits from Exception, so the
+                    # bare `except Exception` would swallow the duplicate-entry abort and
+                    # surface it as "unknown error" instead of "already configured".
+                    await self.async_set_unique_id(processed_input[CONF_API_KEY])
+                    self._abort_if_unique_id_configured()
+                    return self.async_create_entry(title=info["title"], data=processed_input)
 
         return self.async_show_form(
             step_id="user",


### PR DESCRIPTION
## summary

closes #9.

when a user tries to add a second config entry with an api key that is already configured, the flow currently reports `errors["base"] = "unknown"` instead of aborting with `already_configured` (rendered as "This TRMNL account is already configured." from `strings.json`).

## root cause

in `async_step_user`:

```python
try:
    info = await self._validate_input(self.hass, processed_input)
    await self.async_set_unique_id(processed_input[CONF_API_KEY])
    self._abort_if_unique_id_configured()      # raises AbortFlow on duplicate
    return self.async_create_entry(...)
except InvalidAuth:
    errors["base"] = "invalid_auth"
except ConnectionError:
    errors["base"] = "cannot_connect"
except Exception:                              # <-- catches AbortFlow
    _LOGGER.exception("Unexpected exception")
    errors["base"] = "unknown"
```

`AbortFlow` inherits from `FlowError` → `HomeAssistantError` → `Exception`, so the bare `except Exception` swallows it and converts the abort into an `unknown` error code on the form.

this surfaces especially badly for users adding a second physical trmnl on the same account: the integration is account-scoped (`get_devices()` returns all devices on the account, and `sensor.async_setup_entry` iterates over them), so the correct path for them is to **reload the existing entry**, not add a new one. but the misleading "unknown error" pushes them to file bug reports instead.

## fix

move `async_set_unique_id` / `_abort_if_unique_id_configured` / `async_create_entry` into an `else:` block on the try, so that only `_validate_input` is wrapped by the broad `except Exception`. `AbortFlow` then propagates to the flow manager and the `abort.already_configured` string is shown correctly.

## verification

- reproduced on a live ha install (2026-06-17 build) by attempting to add a second entry for the same trmnl account → form returns `errors["base"] = "unknown"` and "An unknown error occurred" is displayed.
- with the patch applied, the second add returns `type: "abort"` with `reason: "already_configured"` and the user sees "This TRMNL account is already configured."

## scope notes

- the same `except Exception` pattern exists in `TrmnlOptionsFlowHandler.async_step_init`, but that one is not affected by the same bug because the options flow does not call `_abort_if_unique_id_configured`. left untouched to keep this pr tight.
- `cannot_connect` and `invalid_base_url_auth` are referenced as error codes but not present in `strings.json` — separate cosmetic issue, not addressed here.

🤖 generated with [claude code](https://claude.com/claude-code)