### PR TITLE
fix: use API percent_charged for battery % instead of linear voltage map

### DIFF
--- a/custom_components/trmnl/sensor.py
+++ b/custom_components/trmnl/sensor.py
@@ -138,9 +138,19 @@ class TrmnlBatteryPercentageSensor(TrmnlBaseSensor):
     def state(self):
         """Return the state of the sensor."""
         device_data = self.get_device_data()
-        if device_data:
-            return calculate_battery_percentage(float(device_data["battery_voltage"]))
-        return None
+        if not device_data:
+            return None
+        # Prefer the device's own state-of-charge estimate (`percent_charged`)
+        # returned by the TRMNL API. Deriving the percentage from `battery_voltage`
+        # via a linear map is unreliable: LiPo voltage is highly non-linear with
+        # charge, and the reported voltage swings outside the 3.0-4.2 V window the
+        # linear map assumes (e.g. it reads ~4.7 V while charging), which clamps
+        # the result to 100% the moment the device is plugged in.
+        percent_charged = device_data.get("percent_charged")
+        if percent_charged is not None:
+            return round(float(percent_charged))
+        # Fall back to the voltage-based estimate if the API omits percent_charged.
+        return calculate_battery_percentage(float(device_data["battery_voltage"]))
 
     @property
     def unit_of_measurement(self):


### PR DESCRIPTION
## relationship to #8

#8 (by @jamesbrindle) spotted this same root cause first — the integration ignores the API's `percent_charged` and derives % from voltage — and reported the same ~9-10% discrepancy. credit to them for finding it. this pr aims to be a cleaner, mergeable version of the same fix:

- **keeps a fallback**: returns the voltage-based estimate when `percent_charged` is absent (older firmware/API responses), rather than returning `None`.
- **no dead code**: leaves `calculate_battery_percentage` intact as the fallback instead of commenting it out.
- **no README/HACS changes**: #8 also re-points the README install badge/instructions to a personal fork; this pr touches only `sensor.py`.

happy to defer to #8 if the maintainer prefers — the important thing is `percent_charged` gets used.

---

## summary

the battery **percentage** sensor is derived from `battery_voltage` with a linear map `((V - 3.0) / (4.2 - 3.0)) * 100` (`calculate_battery_percentage`). this produces misleading values. this pr switches it to the `percent_charged` value the TRMNL API returns, falling back to the voltage estimate only if that field is missing.

## evidence

captured from a live install (TRMNL OG), 5-minute polling, the day it was put on a charger:

```
11:46  battery_voltage=3.17V  -> percentage sensor = 29%
11:56  battery_voltage=3.15V  -> percentage sensor = 28%
12:01  battery_voltage=4.66V  -> percentage sensor = 100%   <- plugged in
12:06  battery_voltage=4.68V  -> percentage sensor = 100%
```

the percentage jumps **28% -> 100% in a single poll interval** the moment the device goes on charge — not a real state-of-charge change.

two root causes:

1. **linear voltage -> % is wrong for LiPo.** voltage is highly non-linear with charge; a straight-line map is inaccurate across most of the usable range (e.g. ~3.2 V resting reads as ~28% here, when for a LiPo that is nearly empty).
2. **reported voltage leaves the assumed window.** `battery_voltage` reads ~4.7 V while charging — above the `MAX_VOLTAGE = 4.2` the map assumes — so it clamps to 100% as soon as it is plugged in. (two devices on the same account read 4.71 V and 4.35 V while both "full", so the raw voltage isn't a normalised SoC signal.)

meanwhile the live `/api/devices` response includes `percent_charged` per device (the device's own SoC estimate, e.g. `100.0`, `99.0`) — which the integration was discarding.

## change

`TrmnlBatteryPercentageSensor.state` now returns `round(percent_charged)` when the API provides it, and only falls back to `calculate_battery_percentage(battery_voltage)` when the field is absent. the voltage sensor and the `calculate_battery_percentage` helper are left untouched.

## notes / scope

- like any battery gauge, `percent_charged` will read ~100% while the device is on charge — expected.
- `percent_charged` is **not** present in this repo's `example_data/api_devices_response.json` (that sample only has `name`/`friendly_id`/`mac_address`/`battery_voltage`/`rssi`), so it appears to be a newer API field. this is exactly why the change keeps the voltage-based fallback rather than assuming the field is always there. happy to add an updated sample payload to `example_data/` if useful.
- does not touch the voltage sensor; users graphing raw voltage keep that as-is.

🤖 generated with [claude code](https://claude.com/claude-code)